### PR TITLE
Update vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,76 +1,17 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-##
-# Variables.
-##
-
-box      = 'precise32'
-url      = 'http://files.vagrantup.com/' + box + '.box'
-hostname = ENV['VD8_HOSTNAME'] || 'd8'
-domain   = ENV['VD8_DOMAIN'] || 'dev'
-cpus     = ENV['VD8_CPUS'] || '1'
-ram      = ENV['VD8_RAM'] || '1024'
-ip_fall  = ENV['VD8_FALLBACK_IP'] || '192.168.50.10'
-
-# These allow for puppet facts to be set. We use these for
-# assigning roles.
-# eg. "drupal" => "true" could setup a Drupal site.
-facts = {
-  'fqdn'          => hostname + '.' + domain,
-  # We set these so we can marry up permissions.
-  'vagrant_uid'   => ENV['VD8_UID'] || Process.uid,
-  'vagrant_group' => ENV['VD8_GROUP'] || 'dialout',
-}
-
-##
-# Configuration.
-##
-
 Vagrant.configure("2") do |config|
-  config.vm.box      = box
-  config.vm.hostname = hostname + '.' + domain
-  config.vm.box_url  = url
+  config.vm.define 'lamp', primary: true do |lamp|
+    lamp.vm.box      = 'pnx/lamp'
+    lamp.vm.hostname = 'd8.dev'
 
-  if Vagrant.has_plugin?('vagrant-auto_network')
-    # Network configured as per bit.ly/1e0ZU1r
-    config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
-  else
-    config.vm.network :private_network, :ip => ip_fall
-  end
-
-  # We want to cater for both Unix and Windows.
-  if RUBY_PLATFORM =~ /linux|darwin/
-    config.vm.synced_folder(
-      ".",
-      "/vagrant",
-      :nfs => true,
-      :map_uid => 0,
-      :map_gid => 0,
-     )
-  else
-    config.vm.synced_folder ".", "/vagrant"
-  end
-
-  # Virtualbox provider configuration.
-  config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm",     :id, "--cpus",                cpus ]
-    vb.customize ["modifyvm",     :id, "--memory",              ram ]
-    vb.customize ["modifyvm",     :id, "--natdnshostresolver1", "on" ]
-    vb.customize ["modifyvm",     :id, "--natdnsproxy1",        "on" ]
-    vb.customize ["modifyvm",     :id, "--nicpromisc1",         "allow-all" ]
-    vb.customize ["modifyvm",     :id, "--nicpromisc2",         "allow-all" ]
-    vb.customize ["modifyvm",     :id, "--nictype1",            "Am79C973" ]
-    vb.customize ["modifyvm",     :id, "--nictype2",            "Am79C973" ]
-    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1" ]
-  end
-
-  # Provisioners.
-  config.vm.provision :shell, :path => "puppet/provision.sh"
-  config.vm.provision :puppet do |puppet|
-    puppet.facter = facts
-    puppet.manifests_path = "puppet"
-    puppet.manifest_file  = "site.pp"
-    puppet.module_path    = "puppet/modules"
+    # This script is a last chance for Developers to add more
+    # configuration to the Vagrant host.
+    #
+    # Examples:
+    #  * Create files directories
+    #  * Setup additional databases
+    # lamp.vm.provision :shell, path: "provision.sh"
   end
 end

--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
                be overridden with project specific configuration.
 -->
 
-<project name="vd8" default="prepare" phingVersion="2.4.11">
+<project name="vd8" default="install" phingVersion="2.4.11">
 
   <!--               -->
   <!--  Properties   -->
@@ -23,11 +23,11 @@
   <property name="modules.enable" value="false" />
 
   <!-- Mysql -->
-  <property name="mysql.host" value="d8.dev" />
+  <property name="mysql.host" value="localhost" />
   <property name="mysql.port" value="3306" />
-  <property name="mysql.database" value="d8" />
-  <property name="mysql.user" value="d8" />
-  <property name="mysql.pass" value="d8" />
+  <property name="mysql.database" value="local" />
+  <property name="mysql.user" value="drupal" />
+  <property name="mysql.pass" value="drupal" />
   <property name="mysql.queryString" value="mysql://${mysql.user}:${mysql.pass}@${mysql.host}/${mysql.database}" />
 
   <!-- Drush -->
@@ -55,27 +55,6 @@
           passthru="${test.passthru}" />
   </target>
 
-  <!-- Runs a command in the Vagrant host -->
-  <target name="vagrant:run"
-          if="drush.cmd"
-          description="Run a command in the vagrant host.">
-    <exec command="vagrant ssh -c '${vagrant.cmd}'"
-          logoutput="${test.output}"
-          passthru="${test.passthru}" />
-  </target>
-
-  <!-- Runs a drush command in the Vagrant host -->
-  <target name="drush:run"
-          description="Run a drush command in the vagrant host.">
-    <input propertyName="drush.command"
-           defaultValue="status"
-           message="Enter the name of the drush command eg. status" />
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app ${drush.command}"  />
-    </phingcall>
-  </target>
-
   <!-- Reinstall the Drupal 8 site. -->
   <target name="reinstall"
           depends="prepare"
@@ -89,7 +68,7 @@
           passthru="${test.passthru}" />
 
     <!-- Ensure we have a fresh settings.php with correct permissions -->
-    <exec command="sudo scp ${drupal.dir}/sites/default/default.settings.php ${drupal.dir}/sites/default/settings.php"
+    <exec command="sudo cp ${drupal.dir}/sites/default/default.settings.php ${drupal.dir}/sites/default/settings.php"
           logoutput="${test.output}"
           passthru="${test.passthru}" />
     <exec command="sudo chmod 777 ${drupal.dir}/sites/default/settings.php"
@@ -97,7 +76,7 @@
           passthru="${test.passthru}" />
 
     <!-- Ensure we have a fresh services.yml with correct permissions -->
-    <exec command="sudo scp ${drupal.dir}/sites/default/default.services.yml ${drupal.dir}/sites/default/services.yml"
+    <exec command="sudo cp ${drupal.dir}/sites/default/default.services.yml ${drupal.dir}/sites/default/services.yml"
           logoutput="${test.output}"
           passthru="${test.passthru}" />
     <exec command="sudo chmod 777 ${drupal.dir}/sites/default/services.yml"
@@ -118,19 +97,17 @@
   <!-- Install the Drupal 8 site. -->
   <target name="install"
           description="Install the Drupal 8 site.">
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app site-install ${drupal.profile} -y --db-url=${mysql.queryString} --account-mail=${drupal.email} --account-name=${drupal.user} --account-pass=${drupal.pass} --site-name=${drupal.siteName}" />
-    </phingcall>
+    <exec command="${drush.cmd} site-install ${drupal.profile} -y --db-url=${mysql.queryString} --account-mail=${drupal.email} --account-name=${drupal.user} --account-pass=${drupal.pass} --site-name=${drupal.siteName}"
+          logoutput="true"
+          passthru="true"/>
   </target>
   
   <!-- Drop the database of the Drupal 8 site. -->
   <target name="db:drop"
           description="Drop the database.">
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app sql-drop -y" />
-    </phingcall>
+    <exec command="${drush.cmd} sql-drop -y"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- Enable given modules -->
@@ -143,19 +120,17 @@
                defaultValue="views views_ui" />
       </then>
     </if>
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app en -y ${modules.list}" />
-    </phingcall>
+    <exec command="${drush.cmd} en -y ${modules.list}"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- Enable Simpletest module -->
   <target name="simpletest:enable"
           description="Enable the Testing module.">
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app en -y simpletest" />
-    </phingcall>
+    <exec command="${drush.cmd} en -y simpletest"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- Test a class -->
@@ -164,10 +139,9 @@
     <input propertyName="test.class"
            defaultValue="Drupal\action\Tests\ConfigurationTest"
            message="Enter class name with namespace." />
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value='cd ${vagrant.dir}/app; php ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url http://d8.dev  --verbose --color --class "${test.class}"' />
-    </phingcall>
+    <exec command="cd ${vagrant.dir}/app; php ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url http://d8.dev  --verbose --color --class '${test.class}'"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- Test a group -->
@@ -176,19 +150,17 @@
     <input propertyName="test.group"
            defaultValue="action"
            message="Enter group name." />
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}/app; php ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url http://d8.dev  --verbose --color '${test.group}'" />
-    </phingcall>
+    <exec command="cd ${vagrant.dir}/app; php ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url http://d8.dev  --verbose --color '${test.group}'"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- Clean temporary tables and files created by Simpletest module. -->
   <target name="simpletest:clean"
           description="Enable the Testing module.">
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app test-clean" />
-    </phingcall>
+    <exec command="${drush.cmd} test-clean"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- PHP CS -->
@@ -197,18 +169,16 @@
     <input propertyName="phpcs.path"
            defaultValue="core"
            message="Enter the path of directory." />
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}/app; ../bin/phpcs --report=full --standard='../vendor/drupal/coder/coder_sniffer/Drupal' ${phpcs.path}" />
-    </phingcall>
+    <exec command="cd ${vagrant.dir}/app; ../bin/phpcs --report=full --standard='../vendor/drupal/coder/coder_sniffer/Drupal' ${phpcs.path}"
+          logoutput="true"
+          passthru="true"/>
   </target>
 
   <!-- Install the Drupal 8 site. -->
   <target name="login"
           description="Log into the Drupal 8 site.">
-    <phingcall target="vagrant:run">
-      <!-- After some properties for inside the Vagrant host. -->
-      <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app -l ${drupal.url} uli" />
-    </phingcall>
+    <exec command="${drush.cmd} -l ${drupal.url} uli"
+          logoutput="true"
+          passthru="true"/>
   </target>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
+  "name": "pnx/vd8",
+  "description": "Vagrant for Drupal 8",
   "require": {
     "drush/drush": "dev-master",
+    "phing/phing": "2.7.*",
     "squizlabs/php_codesniffer": "2.0.*@dev",
     "drupal/coder": "dev-8.x-2.x"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pnx/vd8",
+  "name": "nickschuch/vd8",
   "description": "Vagrant for Drupal 8",
   "require": {
     "drush/drush": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,27 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8e3051260c4c59e2af293e2fe8e3bf74",
+    "hash": "2c4d619aa0162d5d4bd8de6865ac6d1d",
     "packages": [
         {
             "name": "d11wtq/boris",
-            "version": "dev-master",
+            "version": "v1.0.10",
             "source": {
                 "type": "git",
-                "url": "https://github.com/d11wtq/boris.git",
-                "reference": "2a0a3d3a5f34d317577f8dcd98f5f578ad85109a"
+                "url": "https://github.com/borisrepl/boris.git",
+                "reference": "31055b15e2d3fe47f31f6aa8e277f8f3fc7eb483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/d11wtq/boris/zipball/2a0a3d3a5f34d317577f8dcd98f5f578ad85109a",
-                "reference": "2a0a3d3a5f34d317577f8dcd98f5f578ad85109a",
+                "url": "https://api.github.com/repos/borisrepl/boris/zipball/31055b15e2d3fe47f31f6aa8e277f8f3fc7eb483",
+                "reference": "31055b15e2d3fe47f31f6aa8e277f8f3fc7eb483",
                 "shasum": ""
             },
             "require": {
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "ext-readline": "*",
                 "php": ">=5.3.0"
-            },
-            "suggest": {
-                "ext-pcntl": "Optional Process Control extension depencency",
-                "ext-posix": "Optional POSIX extension",
-                "ext-readline": "Optional readline extension depencency"
             },
             "bin": [
                 "bin/boris"
@@ -38,7 +36,11 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2014-07-31 12:15:24"
+            "license": [
+                "MIT"
+            ],
+            "description": "A tiny, but robust REPL (Read-Evaluate-Print-Loop) for PHP.",
+            "time": "2015-03-01 08:05:19"
         },
         {
             "name": "drupal/coder",
@@ -46,28 +48,28 @@
             "source": {
                 "type": "git",
                 "url": "http://git.drupal.org/project/coder.git",
-                "reference": "84906508bcc01419c58d60824d902f04b25d2e26"
+                "reference": "5973c4813fdb1fcf236e7471c263923b6aab9df5"
             },
             "require": {
                 "php": ">=5.2.0",
-                "squizlabs/php_codesniffer": "2.0.*@dev"
+                "squizlabs/php_codesniffer": ">=2.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7"
+                "phpunit/phpunit": ">=3.7"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
             ],
-            "description": "Coder is a library and a module to review Drupal code.",
+            "description": "Coder is a library to review Drupal code.",
             "homepage": "https://drupal.org/project/coder",
             "keywords": [
                 "code review",
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-10-31 00:22:17"
+            "time": "2015-04-26 21:19:02"
         },
         {
             "name": "drush/drush",
@@ -75,18 +77,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "ae404049b4f573024a4a7e6f5f005ca79ee63a4c"
+                "reference": "0f4e59a9ceb1c95fdd4dfff925cc131fec9d83c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/ae404049b4f573024a4a7e6f5f005ca79ee63a4c",
-                "reference": "ae404049b4f573024a4a7e6f5f005ca79ee63a4c",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/0f4e59a9ceb1c95fdd4dfff925cc131fec9d83c1",
+                "reference": "0f4e59a9ceb1c95fdd4dfff925cc131fec9d83c1",
                 "shasum": ""
             },
             "require": {
-                "d11wtq/boris": "*",
+                "d11wtq/boris": "~1.0",
                 "pear/console_table": "~1.2.0",
                 "php": ">=5.3.0",
+                "symfony/var-dumper": "2.6.3",
                 "symfony/yaml": "~2.2"
             },
             "require-dev": {
@@ -100,6 +103,11 @@
                 "drush.complete.sh"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Drush": "lib/"
@@ -137,11 +145,15 @@
                 {
                     "name": "Jonathan Hedstrom",
                     "email": "jhedstrom@gmail.com"
+                },
+                {
+                    "name": "Christopher Gervais",
+                    "email": "chris@ergonlogic.com"
                 }
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2014-11-06 04:56:27"
+            "time": "2015-04-30 00:18:09"
         },
         {
             "name": "pear/console_table",
@@ -199,21 +211,75 @@
             "time": "2014-10-27 10:04:49"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "dev-phpcs-fixer",
+            "name": "phing/phing",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "198692e8e15cb4bde41f31742209f4bf61486af3"
+                "url": "https://github.com/phingofficial/phing.git",
+                "reference": "bd2689790c620ac745b3ad29765c641a0dd5d007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/198692e8e15cb4bde41f31742209f4bf61486af3",
-                "reference": "198692e8e15cb4bde41f31742209f4bf61486af3",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/bd2689790c620ac745b3ad29765c641a0dd5d007",
+                "reference": "bd2689790c620ac745b3ad29765c641a0dd5d007",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "bin": [
+                "bin/phing"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "classes/phing/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "classes"
+            ],
+            "license": [
+                "LGPL3"
+            ],
+            "authors": [
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Phing Community",
+                    "homepage": "http://www.phing.info/trac/wiki/Development/Contributors"
+                }
+            ],
+            "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
+            "homepage": "http://www.phing.info/",
+            "keywords": [
+                "build",
+                "task",
+                "tool"
+            ],
+            "time": "2014-02-13 13:17:59"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "8b75b9c1d842642ecf8997bc3691f0077a5f2546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/8b75b9c1d842642ecf8997bc3691f0077a5f2546",
+                "reference": "8b75b9c1d842642ecf8997bc3691f0077a5f2546",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
                 "php": ">=5.1.2"
             },
             "bin": [
@@ -223,7 +289,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-phpcs-fixer": "2.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -263,31 +329,34 @@
                     "role": "lead"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
             "homepage": "http://www.squizlabs.com/php-codesniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-11-04 00:15:26"
+            "time": "2015-04-30 00:17:37"
         },
         {
-            "name": "symfony/yaml",
-            "version": "dev-master",
-            "target-dir": "Symfony/Component/Yaml",
+            "name": "symfony/var-dumper",
+            "version": "v2.6.3",
+            "target-dir": "Symfony/Component/VarDumper",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "9da3813f36985a4089f7e83c601a1034d125ff69"
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "36af986811340fd4c1bc39cf848da388bbdd8473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/9da3813f36985a4089f7e83c601a1034d125ff69",
-                "reference": "9da3813f36985a4089f7e83c601a1034d125ff69",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/36af986811340fd4c1bc39cf848da388bbdd8473",
+                "reference": "36af986811340fd4c1bc39cf848da388bbdd8473",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
             },
             "type": "library",
             "extra": {
@@ -296,7 +365,59 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
                 "psr-0": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "http://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2015-01-01 13:28:01"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "2.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "4ededb1d00dc2c65fcd16ae3dafc785f92b3f95f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4ededb1d00dc2c65fcd16ae3dafc785f92b3f95f",
+                "reference": "4ededb1d00dc2c65fcd16ae3dafc785f92b3f95f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7|~3.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
                 }
             },
@@ -316,7 +437,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2014-11-03 03:55:50"
+            "time": "2015-04-24 07:03:44"
         }
     ],
     "packages-dev": [],
@@ -327,6 +448,8 @@
         "squizlabs/php_codesniffer": 20,
         "drupal/coder": 20
     },
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }


### PR DESCRIPTION
* Updates vagrant to the pnx/lamp box
* Includes php 5.5

Steps to upgrade:

```
vagrant destroy -f
rm -rf .vagrant
vagrant up
```

All commands should be run inside the vm

```
vagrant ssh
composer install --prefer-dist
rm app/sites/default/settings.php
phing reinstall
```